### PR TITLE
feat(grammar): W17B vocabulary extension from PWI+waves absorbed-power evidence

### DIFF
--- a/imas_standard_names/grammar/vocabularies/physical_bases.yml
+++ b/imas_standard_names/grammar/vocabularies/physical_bases.yml
@@ -19,6 +19,9 @@
 # plausibly a quantity noun after operator/subject/locus decomposition.
 
 bases:
+  absorbed_wave_power:  # Added W17B: wave-heating evidence N=4 (fast_electron_, thermal_ion_, fast_ion_, thermal_electron_absorbed_wave_power_per_toroidal_mode)
+    aliases: []
+    kind: scalar
   accumulated_gas_injection:
     aliases: []
     kind: scalar
@@ -809,6 +812,12 @@ bases:
     aliases: []
     kind: scalar
   wave_absorbed_power:
+    aliases: []
+    kind: scalar
+  wave_absorbed_power_density:  # Added W17B: wave-heating evidence N=5 (wave_absorbed_power_density_per_toroidal_mode + 4 species variants: fast_electron, thermal_electron, fast_ion, thermal_ion)
+    aliases: []
+    kind: scalar
+  wave_absorbed_power_inside_flux_surface:  # Added W17B: wave-heating evidence N=3 (fast_ion_, thermal_electron_, thermal_ion_wave_absorbed_power_inside_flux_surface_per_toroidal_mode); parallel to wave_driven_absorbed_power_inside_flux_surface
     aliases: []
     kind: scalar
   wave_driven_absorbed_power_inside_flux_surface:

--- a/imas_standard_names/schemas/entry_schema.json
+++ b/imas_standard_names/schemas/entry_schema.json
@@ -1339,5 +1339,5 @@
       "$ref": "#/$defs/StandardNameMetadataEntry"
     }
   ],
-  "$schema_version": "0.7.0rc27.dev1+g1982016ed"
+  "$schema_version": "0.7.0rc26.dev2+g05845cdbc.d20260423"
 }


### PR DESCRIPTION
## Summary

Add 3 physical_base tokens from imas-codex W17B mining of low-scoring standard names
(`reviewer_score_name < 0.55`, N=86 total analyzed, 0 VocabGap graph nodes — tokens
identified by manual parsing of compound `physical_base` residues).

**Source:** imas-codex W17B wave-heating + PWI campaign synthesis.
**Evidence gate:** N ≥ 3 distinct names (policy: commit `1982016`).
**Branch:** `w17b-vocab-extension` from `main` (does not touch PR #11's `vocab-rotation-wave7-wave9` branch).

---

## Evidence for new vocabulary tokens

### Tokens proposed

| Token | Segment | Vocab file | N (distinct low-score names) | Sample names |
|-------|---------|------------|------------------------------|--------------|
| `absorbed_wave_power` | physical_base | `physical_bases.yml` | **4** | `fast_electron_absorbed_wave_power_per_toroidal_mode`, `thermal_ion_absorbed_wave_power_per_toroidal_mode`, `fast_ion_absorbed_wave_power_per_toroidal_mode`, `thermal_electron_absorbed_wave_power_per_toroidal_mode` |
| `wave_absorbed_power_density` | physical_base | `physical_bases.yml` | **5** | `wave_absorbed_power_density_per_toroidal_mode`, `fast_electron_wave_absorbed_power_density_per_toroidal_mode`, `thermal_electron_wave_absorbed_power_density_per_toroidal_mode`, `fast_ion_wave_absorbed_power_density_per_toroidal_mode`, `thermal_ion_wave_absorbed_power_density_per_toroidal_mode` |
| `wave_absorbed_power_inside_flux_surface` | physical_base | `physical_bases.yml` | **3** | `fast_ion_wave_absorbed_power_inside_flux_surface_per_toroidal_mode`, `thermal_electron_wave_absorbed_power_inside_flux_surface_per_toroidal_mode`, `thermal_ion_wave_absorbed_power_inside_flux_surface_per_toroidal_mode` |

Evidence gathered from imas-codex VocabGap analysis: parsing 86 low-scoring SNs
(`reviewer_score_name < 0.55`) and extracting unrecognised `physical_base` residue
strings. N counts number of distinct low-scoring names that produce the given
unrecognised residue when the known subject prefix is stripped.

### Why existing tokens do not suffice

- **`absorbed_wave_power`**: `wave_absorbed_power` exists in ISN (canonical word order), but the imas-codex pipeline generates names with `absorbed_wave_power` word order (adjective-noun vs noun-adjective). This token is the evidence-backed variant form needed to satisfy the open-fallback validator.
- **`wave_absorbed_power_density`**: `wave_absorbed_power` covers volumetric power integrals; `wave_absorbed_power_density` (W·m⁻³) is the distinct volumetric density form absent from the vocabulary. Five species variants (fast_electron, thermal_electron, fast_ion, thermal_ion, plus bare) all require it.
- **`wave_absorbed_power_inside_flux_surface`**: Parallel to the already-present `wave_driven_absorbed_power_inside_flux_surface`. Three species-qualified names need the base concept of absorbed wave power cumulated inside a flux surface (W), distinguished from the `wave_driven_` (current-drive context) and the `_density` (W·m⁻³) variants.

---

## Tokens explicitly rejected (preposition-form ban)

| Token | Reason |
|-------|--------|
| `per_toroidal_mode` (postfix) | Grammar policy bans changing existing operator kind; `per_toroidal_mode` is defined as `unary_prefix` with test coverage (`test_d5_vocabulary.py::test_per_toroidal_mode_power_round_trip`). Postfix usage in corpus names is a name-generation bug in imas-codex, not a vocabulary gap. |
| `inside_flux_surface` as preposition | `inside` is a locative preposition; ISN only allows `of`/`at`/`over` locus relations. |
| `per_` style postfixes | Explicitly banned by ISN grammar policy (`_per_` is a preposition). |

## Tokens deferred (N < 3)

| Token | Segment | N | Notes |
|-------|---------|---|-------|
| `wave_power` | physical_base | 1 | Only `fast_electron_wave_power_inside_flux_surface_per_toroidal_mode` — just one name. |
| `peak_power_flux` | physical_base | 2 | `peak_power_flux_of_inner_divertor_target` + outer — just misses gate. |
| `count_rate` | physical_base | 2 | `minimum_count_rate_of_neutron_detector_mode` + maximum — just misses gate. |
| `bidirectional_reflectance_distribution_function` | physical_base | 1 | Single BRDF name; highly domain-specific. Re-evaluate after PWI coverage expansion. |
| `incident_angle` | physical_base | 1 | Only `sputtering_physical_coefficient_incident_angle`. `sputtering_angle_of_incidence` already in vocab; rename preferred. |
| `vessel_annular_outer_outline_point` | position | 1 | Single name; `vessel_outline_point` already in locus_registry (PR #11). |
| `logarithmic_density_gradient` | physical_base | 1 | Only `normalized_logarithmic_density_gradient`. |

## Mining summary

- **86** low-score names analysed (score < 0.55)
- **0** VocabGap nodes in graph (VocabGap node type not populated yet in this codex version)
- **273** compound `physical_base` residues extracted (after subject/locus stripping)
- **3** tokens meet N ≥ 3 gate and are additive (no grammar-rule changes)
- **1** grammar fix identified but deferred (`per_toroidal_mode` prefix→postfix would break `test_d5_vocabulary.py`)

---

## Changes

- `imas_standard_names/grammar/vocabularies/physical_bases.yml` — add `absorbed_wave_power`, `wave_absorbed_power_density`, `wave_absorbed_power_inside_flux_surface`
- `imas_standard_names/schemas/entry_schema.json` — schema-version string bump (auto-generated)

## Testing

- [x] All existing tests pass (`1108 passed, 68 xfailed, 0 failed`)
- [x] Grammar codegen drift check passes
- [ ] New tests not required (vocab-only additions, no grammar-rule changes)

## Checklist

- [x] I have read the CONTRIBUTING.md guidelines
- [x] Conventional commit message format used
- [x] N ≥ 3 evidence provided above for all included tokens
- [x] Branch is from `main`, does not conflict with PR #11 (`vocab-rotation-wave7-wave9`)