### PR TITLE
feat(vocab): W23A evidence-gated physical bases for grammar gap closure

### DIFF
--- a/imas_standard_names/grammar/vocabularies/physical_bases.yml
+++ b/imas_standard_names/grammar/vocabularies/physical_bases.yml
@@ -62,6 +62,9 @@ bases:
   bootstrap_current:
     aliases: []
     kind: scalar
+  bootstrap_current_density:  # W23A: j_bootstrap (core_profiles/profiles_1d/j_bootstrap) — evidence N=5 (core_profiles, core_sources, edge_profiles, plasma_profiles, plasma_sources)
+    aliases: []
+    kind: scalar
   breeding_ratio:
     aliases: []
     kind: scalar
@@ -308,6 +311,9 @@ bases:
   heat_flux:
     aliases: []
     kind: scalar
+  heat_viscosity_current_density:  # W23A: j_heat_viscosity (edge_profiles/ggd/j_heat_viscosity, plasma_profiles/ggd/j_heat_viscosity) — evidence N=4
+    aliases: []
+    kind: vector
   heating_power:
     aliases: []
     kind: scalar
@@ -379,6 +385,9 @@ bases:
     aliases: []
     kind: vector
   lower_outer_squareness:
+    aliases: []
+    kind: scalar
+  mach_number:  # W23A: mach_number_parallel (langmuir_probes/reciprocating/plunge/mach_number_parallel) — evidence N=3
     aliases: []
     kind: scalar
   magnetic_field:
@@ -477,6 +486,9 @@ bases:
   orbit_frequency:
     aliases: []
     kind: scalar
+  parallel_viscosity_current_density:  # W23A: j_parallel_viscosity (edge_profiles/ggd/j_parallel_viscosity, plasma_profiles/ggd/j_parallel_viscosity) — evidence N=4
+    aliases: []
+    kind: vector
   parameter:
     aliases: []
     kind: scalar
@@ -510,6 +522,9 @@ bases:
   particle_radial_diffusivity_on_ggd:
     aliases: []
     kind: scalar
+  perpendicular_viscosity_current_density:  # W23A: j_perpendicular_viscosity (edge_profiles/ggd/j_perpendicular_viscosity, plasma_profiles/ggd/j_perpendicular_viscosity) — evidence N=4
+    aliases: []
+    kind: vector
   perturbed_electrostatic_potential_weight:
     aliases: []
     kind: scalar
@@ -658,7 +673,13 @@ bases:
   resistive_diffusion_time:
     aliases: []
     kind: scalar
+  resistivity:  # W23A: wall/*/resistivity, cryostat/*/resistivity — evidence N=6 (wall, cryostat, pf_active, tf)
+    aliases: []
+    kind: scalar
   resonant_magnetic_perturbation_occurrence:
+    aliases: []
+    kind: scalar
+  rotation_frequency:  # W23A: rotation_frequency_tor (core_profiles, plasma_profiles, edge_profiles) — evidence N=8+
     aliases: []
     kind: scalar
   rotational_pressure:


### PR DESCRIPTION
## W23A Vocabulary Extension — Grammar Gap Closure

### Context

W22B review score analysis identified three vocabulary gap classes dragging mean scores from ~0.660 to below the 0.733 target. This PR addresses **Class 2 (physics compound nouns)** with 7 new `physical_base` tokens.

### Evidence & Rationale

| Token | DD Source | Evidence (N≥3) | W22B Impact |
|-------|-----------|----------------|-------------|
| `bootstrap_current_density` | `core_profiles/profiles_1d/j_bootstrap` | N=5 | scored 0.450 |
| `rotation_frequency` | `core_profiles/profiles_1d/ion/rotation_frequency_tor` | N=8+ | scored 0.563 |
| `mach_number` | `langmuir_probes/reciprocating/plunge/mach_number_parallel` | N=3 | edge plasma |
| `resistivity` | `wall/*/resistivity`, `cryostat/*/resistivity` | N=6 | material property |
| `heat_viscosity_current_density` | `edge_profiles/ggd/j_heat_viscosity` | N=4 | gyroviscous j |
| `parallel_viscosity_current_density` | `edge_profiles/ggd/j_parallel_viscosity` | N=4 | parallel viscous j |
| `perpendicular_viscosity_current_density` | `edge_profiles/ggd/j_perpendicular_viscosity` | N=4 | perp viscous j |

All tokens meet the N>=3 evidence gate.

### Test Results

1107 passed, 68 xfailed, 53 warnings.