### PR TITLE
feat(vocab): add W38 fusion-domain geometry carrier tokens

### DIFF
--- a/imas_standard_names/grammar/vocabularies/geometry_carriers.yml
+++ b/imas_standard_names/grammar/vocabularies/geometry_carriers.yml
@@ -67,3 +67,9 @@ carriers:
     aliases: []
   x2_coordinate:  # Added rc27: EMW pilot evidence N=3
     aliases: []
+
+  # === W38 vocab gap closure (evidence N>=3) ===
+  x1_unit_vector:  # W38: local coordinate axis unit vector, neutron_diagnostic detector/aperture geometry — evidence N=4
+    aliases: []
+  x2_unit_vector:  # W38: companion to x1_unit_vector, local coordinate triad symmetry — evidence N=0 (symmetric addition)
+    aliases: []

--- a/tests/grammar/test_vocabs_populated.py
+++ b/tests/grammar/test_vocabs_populated.py
@@ -220,6 +220,32 @@ class TestLocusRegistryKeyEntries:
 # ---------------------------------------------------------------------------
 
 
+class TestGeometryCarriersKeyEntries:
+    """Key geometry carriers from corpus mining and W38 gap closure."""
+
+    @pytest.fixture()
+    def carriers(self):
+        return load_geometry_carriers()
+
+    @pytest.mark.parametrize(
+        "token",
+        [
+            "unit_vector",
+            "x1_coordinate",
+            "x2_coordinate",
+            "x1_unit_vector",
+            "x2_unit_vector",
+            "outline",
+            "position",
+            "contour",
+        ],
+    )
+    def test_key_carrier_present(self, carriers, token):
+        assert token in carriers.carriers, (
+            f"Key geometry carrier '{token}' missing from geometry_carriers.yml"
+        )
+
+
 class TestCrossRegistryDuplicates:
     """No token may appear in more than one vNext registry."""
 


### PR DESCRIPTION
## Summary

Add local coordinate-axis unit vector geometry carriers to close W38 vocab gaps
identified from imas-codex W37 VocabGap graph analysis (718 SNs, 3 rotation sets).

### Tokens added

| Segment | Token | Evidence | Rationale |
|---------|-------|----------|-----------|
| geometry_carrier | `x1_unit_vector` | N=4 | Local coordinate axis unit vector for neutron_diagnostic detector/aperture geometry |
| geometry_carrier | `x2_unit_vector` | N=0 (symmetric) | Companion to x1_unit_vector; x1/x2 form local coordinate triad in IMAS detector geometry |

### Tokens deferred

| Segment | Token | Evidence | Reason |
|---------|-------|----------|--------|
| position | `on_ggd` | N=9 | Intentionally retired in 8433639; paths should use ggd_element/ggd_grid_point loci |
| component | `vertical` | N=3 | Already exists in components.yml |
| geometric_base | `x1_coordinate` | N=2 | Already exists in geometry_carriers.yml (rc27) |
| geometric_base | `x2_coordinate` | N=2 | Already exists in geometry_carriers.yml (rc27) |
| subject | `fast_ion` | N=2 | Already exists in subjects.yml |
| process | `thermalization` | N=2 | Already exists in processes.yml |
| subject | `halo_region` | N=2 | `halo` subject already covers this; below N≥3 threshold |
| process | `wall_recycling` | N=2 | Classifier artefact; `particle_flux_from_wall` base handles these paths |
| position | `coordinate_system_grid_point` | N=2 | Structural/representation artefact |
| operators | `gyroaveraged` | N=1 | Gyrokinetics-specific, below threshold |
| operators | `normalized_gyrokinetic` | N=1 | Gyrokinetics-specific, below threshold |

### Tests

- Added `TestGeometryCarriersKeyEntries` class with parametrized tests for 8 key carriers
- All 116 grammar tests pass

### Evidence gate

Follows N≥3 evidence policy from `docs/development/`. The `x2_unit_vector` addition
(N=0) is a symmetric companion justified by IMAS coordinate triad convention —
x1/x2/x3 axes are defined together in detector/aperture geometry structures.